### PR TITLE
Fix schema.org catalog metadata example

### DIFF
--- a/dummyrepository/metadata/catalog_metadata_schemaorg.json
+++ b/dummyrepository/metadata/catalog_metadata_schemaorg.json
@@ -92,7 +92,7 @@
       "@type": "schema:Offer",
       "schema:itemOffered": {
         "@type": "schema:Service",
-        "schema:documentation": "http://www.dcc.ac.uk/resources/metadata-standards/dcat-data-catalog-vocabulary",
+        "schema:documentation": "https://w3id.org",
         "schema:serviceType": "https://w3id.org/fair/fip/latest/Identifier-service"
       }
     },
@@ -100,7 +100,7 @@
       "@type": "schema:Offer",
       "schema:itemOffered": {
         "@type": "schema:Service",
-        "schema:documentation": "https://w3id.org",
+        "schema:documentation": "http://www.dcc.ac.uk/resources/metadata-standards/dcat-data-catalog-vocabulary",
         "schema:serviceType": "https://w3id.org/fair/fip/latest/Metadata-schema"
       }
     }


### PR DESCRIPTION
There is a typo in the `schema:Service`: Identifier-service and Metadata-schema `schema:documentation` fields need to swap values. Cf. https://github.com/FAIRsFAIR/5_4_prototype/blob/main/dummyrepository/metadata/catalog_metadata_dcat.json